### PR TITLE
Replace defaults in settings to use %u syntax

### DIFF
--- a/src/main/java/me/tolek/modules/settings/AutoWbJoinRegex.java
+++ b/src/main/java/me/tolek/modules/settings/AutoWbJoinRegex.java
@@ -6,8 +6,8 @@ import me.tolek.util.RegexUtil;
 public class AutoWbJoinRegex extends StringSetting {
 
     public AutoWbJoinRegex() {
-        super("Join RegEx", "^[a-zA-Z0-9_]{3,16} has joined\\.$", "The RegEx to use to match if a message contains the user has joined text.");
-        this.setState("^[a-zA-Z0-9_]{3,16} has joined\\.$");
+        super("Join RegEx", "^%u has joined\\.$", "The RegEx to use to match if a message contains the user has joined text.");
+        this.setState("^%u has joined\\.$");
         this.render = false;
     }
 

--- a/src/main/java/me/tolek/modules/settings/AutoWbUnAfkRegex.java
+++ b/src/main/java/me/tolek/modules/settings/AutoWbUnAfkRegex.java
@@ -6,8 +6,8 @@ import me.tolek.util.RegexUtil;
 public class AutoWbUnAfkRegex extends StringSetting {
 
     public AutoWbUnAfkRegex() {
-        super("Un-AFK RegEx", "^[a-zA-Z0-9_]{3,16} is no longer AFK\\.$", "The RegEx to use to match if a message contains the user has returned from afk text.");
-        this.setState("^[a-zA-Z0-9_]{3,16} is no longer AFK\\.$");
+        super("Un-AFK RegEx", "^%u is no longer AFK\\.$", "The RegEx to use to match if a message contains the user has returned from afk text.");
+        this.setState("^%u is no longer AFK\\.$");
         this.render = false;
     }
 


### PR DESCRIPTION
The default values in `AutoWbJoinRegex` and `AutoWbUnAfkRegex` have been changed to use the `%u` variable.